### PR TITLE
repr methods must return str.  Also, pass client to remotely.

### DIFF
--- a/afar/reprs.py
+++ b/afar/reprs.py
@@ -93,9 +93,7 @@ def get_repr_methods():
         return
     attr_recorder = AttrRecorder()
     ip.display_formatter.format(attr_recorder)
-    repr_methods = attr_recorder._attrs
-    repr_methods.append("__repr__")
-    return repr_methods
+    return attr_recorder._attrs
 
 
 def repr_afar(val, repr_methods):
@@ -118,8 +116,10 @@ def repr_afar(val, repr_methods):
             rv = traceback.format_exception(*exc_info)
             return rv, method_name, True
         else:
+            if rv is None or not isinstance(rv, str):
+                continue
             return rv, method_name, False
-    return None, "__repr__", False
+    return repr(val), "__repr__", False
 
 
 def display_repr(results):


### PR DESCRIPTION
Notably, `pandas.Series._repr_latex_` return `None` instead of raising `NotImplementedError`.  So, let's be more strict and require a rich repr to return a string for us to use it.

Also, allow `remotely(client=client)`.