### PR TITLE
Set `pure=False` when submitting our magic code.

### DIFF
--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Notebook test
         if: (! contains(matrix.python-version, 'pypy')) || (! contains(matrix.os, 'windows'))
         run: |
-          pip install nbconvert jupyter
+          pip install nbconvert jupyter pytest
           jupyter nbconvert --to notebook --execute afar/tests/*ipynb
 
   finish:

--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -47,9 +47,9 @@ jobs:
           coverage report --show-missing
           coveralls --service=github
       - name: Notebook test
-        if: (! contains(matrix.python-version, 'pypy')) || (! contains(matrix.os, 'windows'))
+        if: (! contains(matrix.python-version, 'pypy'))
         run: |
-          pip install nbconvert jupyter pytest
+          pip install nbconvert jupyter
           jupyter nbconvert --to notebook --execute afar/tests/*ipynb
 
   finish:

--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -26,6 +26,7 @@ jobs:
           pip install -r requirements.txt
           pip install -e .
       - name: PyTest
+        if: (! contains(matrix.python-version, 'pypy')) || contains(matrix.os, 'windows')
         run: |
           pip install pytest coverage
           coverage run --branch -m pytest

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@
 > _Robert A. Heinlein_
 <hr>
 
+**To install:** `pip install afar`
+
 `afar` allows you to run code on a remote [Dask](https://dask.org/) [cluster](https://distributed.dask.org/en/latest/) using context managers.  For example:
 ```python
 import afar
+from dask.distributed import Client
+client = Client()
 
 with afar.run, remotely:
     import dask_cudf

--- a/afar/core.py
+++ b/afar/core.py
@@ -38,7 +38,7 @@ class Where:
     def __exit__(self, exc_type, exc_value, exc_traceback):  # pragma: no cover
         return False
 
-    def __call__(self, *, client=None, **submit_kwargs):
+    def __call__(self, client=None, **submit_kwargs):
         return Where(self.where, client, submit_kwargs)
 
 
@@ -194,7 +194,9 @@ class Run:
         if self._where == "remotely":
             if client is None:
                 client = distributed.client._get_global_client()
-            remote_dict = client.submit(run_afar, self._magic_func, names, futures, **submit_kwargs)
+            remote_dict = client.submit(
+                run_afar, self._magic_func, names, futures, pure=False, **submit_kwargs
+            )
             if display_expr:
                 repr_val = client.submit(
                     reprs.repr_afar,

--- a/afar/reprs.py
+++ b/afar/reprs.py
@@ -116,7 +116,12 @@ def repr_afar(val, repr_methods):
             rv = traceback.format_exception(*exc_info)
             return rv, method_name, True
         else:
-            if rv is None or not isinstance(rv, str):
+            if rv is None:
+                continue
+            if method_name == "_repr_mimebundle_":
+                if not isinstance(rv, (dict, tuple)):
+                    continue
+            elif not isinstance(rv, str):
                 continue
             return rv, method_name, False
     return repr(val), "__repr__", False

--- a/afar/reprs.py
+++ b/afar/reprs.py
@@ -106,6 +106,7 @@ def repr_afar(val, repr_methods):
         if method is None:
             continue
         if method_name == "_ipython_display_":
+            # Custom display!  Send the object to the client
             return val, method_name, False
         try:
             rv = method()

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ ignore =
 
 [coverage:run]
 source = afar
+branch = True
 omit =
     afar/_version.py,
     afar/tests/*


### PR DESCRIPTION
We don't know whether it's pure or not, so let's assume it's not.

I'm not sure whether this is strictly necessary or helps anywhere.  Seems like maybe an okay idea to do.