### PR TITLE
Try to work with `%%time` and `%%timeit` IPython magic.

### DIFF
--- a/afar/__init__.py
+++ b/afar/__init__.py
@@ -1,6 +1,5 @@
-from .core import run, get, remotely, locally, later  # noqa
-
 from ._version import get_versions
+from .core import get, later, locally, remotely, run  # noqa
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/afar/core.py
+++ b/afar/core.py
@@ -140,7 +140,7 @@ class Run:
                 lines = cell.splitlines(keepends=True)
                 # strip the magic
                 for i, line in enumerate(lines):
-                    if line.strip().startswith("%%"):
+                    if line.strip().startswith("%%time"):
                         lines = lines[i + 1 :]
                         break
                 else:

--- a/afar/tests/test_core.py
+++ b/afar/tests/test_core.py
@@ -1,7 +1,9 @@
-import afar
 import pickle
+
 import pytest
 from pytest import raises
+
+import afar
 
 
 def test_a_modest_beginning():

--- a/afar/tests/test_later.py
+++ b/afar/tests/test_later.py
@@ -1,5 +1,6 @@
-import afar
 from pytest import raises
+
+import afar
 
 
 def test_later_doesnt_execute():

--- a/afar/tests/test_remotely.py
+++ b/afar/tests/test_remotely.py
@@ -1,8 +1,10 @@
 import subprocess
 import sys
-import afar
 from operator import add
+
 from dask.distributed import Client
+
+import afar
 
 # TODO: better testing infrastructure
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,14 @@ ignore =
     E231,   # Multiple spaces around ","
     W503,   # line break before binary operator
 
+[isort]
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+profile = black
+skip_gitignore = true
+force_to_top = true
+default_section = THIRDPARTY
+known_first_party = afar
+
 [coverage:run]
 source = afar
 branch = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ ignore =
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 profile = black
 skip_gitignore = true
-force_to_top = true
+float_to_top = true
 default_section = THIRDPARTY
 known_first_party = afar
 


### PR DESCRIPTION
Fixes #10.  This is a pretty narrow fix that only applies to time and timeit.

@jrbourbeau care to give this a try, or should I just cut a release and hope for the best?

Testing notebooks is on my TODO list (and I want it to count towards line coverage too).  I'll be sure to add `%%time` and `%%timeit`.  I figured the line magic `%time` wasn't worth supporting.