### PR TITLE
Don't advertise `afar` works with PyPy.

### DIFF
--- a/.github/workflows/test_conda.yml
+++ b/.github/workflows/test_conda.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         shell: bash -l {0}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: [3.7, 3.8, 3.9]  # , "3.7.10 1_73_pypy"]

--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -13,6 +13,11 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: [3.7, 3.8, 3.9, "pypy-3.7"]
+        exclude:
+          - os: "ubuntu-latest"
+            python-version: "pypy-3.7"
+          - os: "macos-latest"
+            python-version: "pypy-3.7"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,7 +31,6 @@ jobs:
           pip install -r requirements.txt
           pip install -e .
       - name: PyTest
-        if: (! contains(matrix.python-version, 'pypy')) || contains(matrix.os, 'windows')
         run: |
           pip install pytest coverage
           coverage run --branch -m pytest
@@ -37,7 +41,6 @@ jobs:
           flake8 .
           black afar *.py --check --diff
       - name: Coverage
-        if: (! contains(matrix.python-version, 'pypy'))
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
           COVERALLS_FLAG_NAME: ${{ matrix.python-version}}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # **Afar**
-[![Python Version](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%20PyPy-blue)](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9)
+[![Python Version](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue)](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue)
 [![Version](https://img.shields.io/pypi/v/afar.svg)](https://pypi.org/project/afar/)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/eriknw/afar/blob/main/LICENSE)
 [![Build Status](https://github.com/eriknw/afar/workflows/Test/badge.svg)](https://github.com/eriknw/afar/actions)


### PR DESCRIPTION
The core bits of `afar` appear to work with PyPy, and we still test PyPy on Windows using pip.  However, since `distributed` doesn't test against PyPy--and the tests that use `distributed` stall--I don't want the burden to try to support PyPy.