### PR TITLE
Set attributes to LocalPrint as if we wrapped print.

### DIFF
--- a/afar/_printing.py
+++ b/afar/_printing.py
@@ -12,6 +12,12 @@ from dask.distributed import get_worker
 # So, use `threading.local` and a lock for some ugly capturing.
 class LocalPrint(local):
     printer = None
+    # Update fields from `functools.WRAPPER_ASSIGNMENTS` as if we wrapped print
+    # See: https://github.com/eriknw/afar/issues/29
+    __module__ = builtins.print.__module__
+    __name__ = builtins.print.__name__
+    __qualname__ = builtins.print.__qualname__
+    __doc__ = builtins.print.__doc__
 
     def __call__(self, *args, **kwargs):
         return self.printer(*args, **kwargs)


### PR DESCRIPTION
Fixes #29 (probably).  This was a quick and easy fix, so let's see how far it takes us.

@jcrist's suggestion to instead monkey-patch `sys.stdout` (and `sys.stderr`) is a good idea, and we may want to give it a try too.

@ncclementi I plan to merge this and release `afar`.  This fixes the bug you reported, so hopefully things will "just work" after this 🤞 