### PR TITLE
Allow users to create their own IPython magics

### DIFF
--- a/.github/workflows/test_conda.yml
+++ b/.github/workflows/test_conda.yml
@@ -36,6 +36,8 @@ jobs:
       - name: PyTest
         run: |
           which python  # sanity check
+          python -c 'from distributed.utils import is_kernel'
+          python -c 'from dask import distributed'
           pytest
       - name: Notebook test
         run: |

--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -33,6 +33,8 @@ jobs:
       - name: PyTest
         run: |
           pip install pytest coverage
+          python -c 'from distributed.utils import is_kernel'
+          python -c 'from dask import distributed'
           coverage run --branch -m pytest
       - name: Style checks
         if: (! contains(matrix.python-version, 'pypy'))

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ with afar.get, remotely:
 assert five == 5
 ```
 ## Interactivity in Jupyter
-There are several enhancements when using `afar` in Jupyter Notebook or Qt console, JupyterLab, or any IPython-based frontend that supports rich display.
+There are several enhancements when using `afar` in Jupyter Notebook or Qt console, JupyterLab, or any IPython-based frontend.
 
 The rich repr of the final expression will be displayed if it's not an assignment:
 ```python
@@ -71,7 +71,7 @@ with afar.run, remotely:
 # displays 10!
 ```
 
-Printing is captured and displayed locally:
+Printing is captured and displayed locally and asynchronously:
 ```python
 with afar.run, remotely:
     print(three)
@@ -96,6 +96,20 @@ and
 ```python
 z = %afar x + y
 ```
+
+### Custom Magic
+You can create your own IPython magic like `%afar` that has arguments baked in:
+```python
+afar.new_magic("on_gpus", where=remotely(resources={"GPU": 1}))
+```
+then:
+```python
+%%on_gpus
+import dask_cudf
+df = dask_cudf.read_parquet("s3://...")
+result = df.sum().compute()
+```
+
 ## Is this a good idea?
 
 I don't know, but it sure is a joy to use 😃 !

--- a/afar/__init__.py
+++ b/afar/__init__.py
@@ -13,12 +13,16 @@ or to use an IPython magic:
 Read the documentation at https://github.com/eriknw/afar
 """
 
+from . import _utils
 from ._core import get, run  # noqa
 from ._version import get_versions
 from ._where import later, locally, remotely  # noqa
 
 __version__ = get_versions()["version"]
 del get_versions
+
+if _utils.is_ipython():
+    from ._magic import new_magic  # noqa
 
 
 def load_ipython_extension(ip):

--- a/afar/_magic.py
+++ b/afar/_magic.py
@@ -6,6 +6,9 @@ from IPython import get_ipython
 from IPython.core.error import UsageError
 from IPython.core.magic import Magics, line_cell_magic, magics_class, needs_local_scope
 
+from ._core import Run, get, run
+from ._where import Where, remotely
+
 DOC_TEMPLATE = """Execute the cell on a dask.distributed cluster.
 
 Usage, in line mode:
@@ -16,12 +19,7 @@ Usage, in cell mode
     code...
 
 Options:
-
-{get_desc}
-{run_desc}
-{data_desc}
-{where_desc}
-{client_desc}
+{get_desc} {run_desc} {data_desc} {where_desc} {client_desc}
   <variable_names>
     Variable names (space- or comma-separated) from the cell to copy to the local
     namespace as dask Future objects.
@@ -71,9 +69,6 @@ DOC_DEFAULTS = {
 
 class AfarMagicBase(Magics):
     def _run(self, line, cell=None, *, local_ns, runner=None, data=None, where=None, client=None):
-        from ._core import Run, get, run
-        from ._where import Where, remotely
-
         options = ""
         args = []
         if runner is None:

--- a/afar/_magic.py
+++ b/afar/_magic.py
@@ -2,69 +2,97 @@
 from textwrap import indent
 
 from dask.distributed import Client
+from IPython import get_ipython
 from IPython.core.error import UsageError
 from IPython.core.magic import Magics, line_cell_magic, magics_class, needs_local_scope
 
-from ._core import Run, get, run
-from ._where import Where, remotely
+DOC_TEMPLATE = """Execute the cell on a dask.distributed cluster.
+
+Usage, in line mode:
+    %{name} [{get_arg}{run_arg}{data_arg}{where_arg}{client_arg}] code_to_run
+Usage, in cell mode
+    %%{name} [{get_arg}{run_arg}{data_arg}{where_arg}{client_arg} <variable_names>]
+    code...
+    code...
+
+Options:
+
+{get_desc}
+{run_desc}
+{data_desc}
+{where_desc}
+{client_desc}
+  <variable_names>
+    Variable names (space- or comma-separated) from the cell to copy to the local
+    namespace as dask Future objects.
+
+All arguments given in options must be variable names in the local namespace.
+
+Examples
+--------
+::
+
+    In [1]: %%{name} x, y
+       ...: x = 1
+       ...: y = x + 1
+
+    In [2]: z = %{name} x + y
+
+"""
+DOC_DEFAULTS = {
+    "name": "afar",
+    "get_arg": "-g",
+    "run_arg": " -r run",
+    "data_arg": " -d data",
+    "where_arg": " -w where",
+    "client_arg": " -c client",
+    "get_desc": (
+        "\n  -g/--get\n"
+        "    Get results as values, not as futures.  This uses `afar.get` instead of `afar.run`.\n"
+    ),
+    "run_desc": (
+        "\n  -r/--run <run>\n"
+        "    A `Run` object from the local namespace such as `run = afar.run(data=mydata)`\n"
+    ),
+    "data_desc": (
+        "\n  -d/--data <data>\n"
+        "    A MutableMapping to use for the data; typically part of a `Run` object.\n"
+    ),
+    "where_desc": (
+        "\n  -w/--where <where>\n"
+        '    A `Where` object such as `where = remotely(resources={"GPU": 1})`\n'
+    ),
+    "client_desc": (
+        "\n  -c/--client <client>\n"
+        "    A `dask.distributed.Client` object from the local namespace.\n"
+    ),
+}
 
 
-@magics_class
-class AfarMagic(Magics):
-    @needs_local_scope
-    @line_cell_magic
-    def afar(self, line, cell=None, *, local_ns):
-        """Execute the cell on a dask.distributed cluster.
+class AfarMagicBase(Magics):
+    def _run(self, line, cell=None, *, local_ns, runner=None, data=None, where=None, client=None):
+        from ._core import Run, get, run
+        from ._where import Where, remotely
 
-        Usage, in line mode:
-            %afar [-g -r run -d data -w where -c client] code_to_run
-        Usage, in cell mode
-            %%afar [-g -r run -d data -w where -c client <variable_names>]
-            code...
-            code...
-
-        Options:
-
-          -g/--get
-            Get results as values, not as futures.  This uses `afar.get` instead of `afar.run`.
-
-          -r/--run <run>
-            A `Run` object from the local namespace such as `run = afar.run(data=mydata)`
-
-          -d/--data <data>
-            A MutableMapping to use for the data; typically part of a `Run` object.
-
-          -w/--where <where>
-            A `Where` object such as `where = remotely(resources={"GPU": 1})`
-
-          -c/--client <client>
-            A `dask.distributed.Client` object from the local namespace.
-
-          <variable_names>
-            Variable names (space- or comma-separated) from the cell to copy to the local
-            namespace as dask Future objects.
-
-        All arguments given in options must be variable names in the local namespace.
-
-        Examples
-        --------
-        ::
-
-            In [1]: %%afar x, y
-               ...: x = 1
-               ...: y = x + 1
-
-            In [2]: z = %afar x + y
-
-        """
+        options = ""
+        args = []
+        if runner is None:
+            options += "gr:"
+            args.append("get")
+            args.append("run=")
+        if data is None:
+            options += "d:"
+            args.append("data=")
+        if where is None:
+            options += "w:"
+            args.append("where=")
+        if client is None:
+            options += "c:"
+            args.append("client=")
         opts, line = self.parse_options(
             line,
-            "gr:d:w:c:",
-            "get",
-            "run=",
-            "data=",
-            "where=",
-            "client=",
+            options,
+            *args,
             posix=False,
             strict=False,
             preserve_non_opts=True,
@@ -77,10 +105,11 @@ class AfarMagic(Magics):
             raise UsageError("-w and --where options may not be used at the same time")
         if "c" in opts and "client" in opts:
             raise UsageError("-c and --client options may not be used at the same time")
-        where = remotely
 
         not_found = "argument not found in local namespace"
-        if "r" in opts or "run" in opts:
+        if runner is not None:
+            pass
+        elif "r" in opts or "run" in opts:
             runner = opts.get("r", opts.get("run"))
             if runner not in local_ns:
                 raise UsageError(f"Variable name {runner!r} for -r or --run {not_found}")
@@ -90,18 +119,22 @@ class AfarMagic(Magics):
             runner = get()
         else:
             runner = run()
-        client = runner.client
 
-        data = runner.data
-        if "d" in opts or "data" in opts:
+        if data is not None:
+            pass
+        elif "d" in opts or "data" in opts:
             data = opts.get("d", opts.get("data"))
             if data not in local_ns:
                 raise UsageError(f"Variable name {data!r} for -d or --data {not_found}")
             data = local_ns[data]
+        else:
+            data = runner.data
         if data is None:
             data = {}
 
-        if "w" in opts or "where" in opts:
+        if where is not None:
+            pass
+        elif "w" in opts or "where" in opts:
             where = opts.get("w", opts.get("where"))
             if where not in local_ns:
                 raise UsageError(f"Variable name {where!r} for -w or --where {not_found}")
@@ -110,10 +143,12 @@ class AfarMagic(Magics):
                 raise UsageError(
                     f"-w or --where argument must be of type Where; got: {type(where)}"
                 )
-            if client is None:
-                client = where.client
+        else:
+            where = remotely
 
-        if "c" in opts or "client" in opts:
+        if client is not None:
+            pass
+        elif "c" in opts or "client" in opts:
             client = opts.get("c", opts.get("client"))
             if client not in local_ns:
                 raise UsageError(f"Variable name {client!r} for -c or --client {not_found}")
@@ -122,6 +157,8 @@ class AfarMagic(Magics):
                 raise UsageError(
                     f"-c or --client argument must be of type Client; got: {type(client)}"
                 )
+        else:
+            client = runner.client or where.client
 
         if cell is None:
             names = ()
@@ -157,3 +194,63 @@ class AfarMagic(Magics):
             submit_kwargs=where.submit_kwargs,
             return_expr=cell is None,
         )
+
+
+@magics_class
+class AfarMagic(AfarMagicBase):
+    @needs_local_scope
+    @line_cell_magic
+    def afar(self, line, cell=None, *, local_ns):
+        return self._run(line, cell, local_ns=local_ns)
+
+    afar.__doc__ = DOC_TEMPLATE.format(**DOC_DEFAULTS)
+
+
+def new_magic(name, *, run=None, data=None, where=None, client=None):
+    """Create new IPython magic to run afar with the given arguments.
+
+    This is like `%%afar` magic with arguments curried or "baked in".
+
+    Examples
+    --------
+    ::
+
+        In [1]: afar.new_magic("on_gpus", where=remotely(resources={"GPU": 1}))
+
+        In [2]: %%on_gpus x, y
+           ...: x = 1
+           ...: y = x + 1
+
+        In [3]: z = %on_gpus x + y
+
+    """
+
+    def magic_method(self, line, cell=None, *, local_ns):
+        return self._run(
+            line, cell, local_ns=local_ns, runner=run, data=data, where=where, client=client
+        )
+
+    d = dict(DOC_DEFAULTS, name=name)
+    if run is not None:
+        d["get_arg"] = ""
+        d["get_desc"] = ""
+        d["run_arg"] = ""
+        d["run_desc"] = ""
+    if data is not None:
+        d["data_arg"] = ""
+        d["data_desc"] = ""
+    if where is not None:
+        d["where_arg"] = ""
+        d["where_desc"] = ""
+    if client is not None:
+        d["client_arg"] = ""
+        d["client_desc"] = ""
+    magic_method.__name__ = name
+    magic_method.__doc__ = DOC_TEMPLATE.format(**d)
+
+    @magics_class
+    class AfarNewMagic(AfarMagicBase):
+        locals()[name] = needs_local_scope(line_cell_magic(magic_method))
+
+    ip = get_ipython()
+    ip.register_magics(AfarNewMagic)


### PR DESCRIPTION
CC @jrbourbeau who first asked for IPython magic.

With this, you can create your own IPython magic like `%afar` that has arguments baked in:
```python
afar.new_magic("on_gpus", where=remotely(resources={"GPU": 1}))
```
then:
```python
%%on_gpus
import dask_cudf
df = dask_cudf.read_parquet("s3://...")
result = df.sum().compute()
```